### PR TITLE
Add tests for CRDLConnector.fetchCodeList

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,13 @@
+version = 3.9.6
+
+runner.dialect = scala3
+
+preset = defaultWithAlign
+
+maxColumn = 100
+
+indent {
+  callSite = 2
+  defnSite = 2
+  extendSite = 2
+}

--- a/app/uk/gov/hmrc/crdlcacheadminfrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/crdlcacheadminfrontend/config/AppConfig.scala
@@ -21,11 +21,11 @@ import play.api.Configuration
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 @Singleton
-class AppConfig @Inject(servicesConfig: ServicesConfig)(val config: Configuration) {
+class AppConfig @Inject() (val config: Configuration) extends ServicesConfig(config)  {
   lazy val welshLanguageSupportEnabled: Boolean =
     config.getOptional[Boolean]("features.welsh-language-support").getOrElse(false)
 
-  lazy val crdlCacheUrl: String = s"${servicesConfig.baseUrl("crdl-cache")}/crdl-cache"
+  lazy val crdlCacheUrl: String = s"${baseUrl("crdl-cache")}/crdl-cache"
 
   lazy val internalAuthToken: String = config.get[String]("internal-auth.token")
 }

--- a/it/test/resources/__files/codelist/BC36-filterkeys.json
+++ b/it/test/resources/__files/codelist/BC36-filterkeys.json
@@ -1,0 +1,26 @@
+[
+  {
+    "key": "E600",
+    "value": "Saturated acyclic hydrocarbons Products falling within CN code 2901 10",
+    "properties": {
+      "unitOfMeasureCode": "1",
+      "degreePlatoApplicabilityFlag": false,
+      "actionIdentification": "1103",
+      "exciseProductsCategoryCode": "E",
+      "alcoholicStrengthApplicabilityFlag": false,
+      "densityApplicabilityFlag": false
+    }
+  },
+  {
+    "key": "T300",
+    "value": "Cigars & cigarillos",
+    "properties": {
+      "unitOfMeasureCode": "4",
+      "degreePlatoApplicabilityFlag": false,
+      "actionIdentification": "1116",
+      "exciseProductsCategoryCode": "T",
+      "alcoholicStrengthApplicabilityFlag": false,
+      "densityApplicabilityFlag": false
+    }
+  }
+]

--- a/it/test/resources/__files/codelist/BC36-filterproperties.json
+++ b/it/test/resources/__files/codelist/BC36-filterproperties.json
@@ -1,0 +1,14 @@
+[
+  {
+    "key": "S200",
+    "value": "Spirituous beverages",
+    "properties": {
+      "unitOfMeasureCode": "3",
+      "degreePlatoApplicabilityFlag": false,
+      "actionIdentification": "1110",
+      "exciseProductsCategoryCode": "S",
+      "alcoholicStrengthApplicabilityFlag": true,
+      "densityApplicabilityFlag": false
+    }
+  }
+]

--- a/it/test/resources/__files/codelist/BC36-nofilter.json
+++ b/it/test/resources/__files/codelist/BC36-nofilter.json
@@ -1,0 +1,38 @@
+[
+  {
+    "key": "E600",
+    "value": "Saturated acyclic hydrocarbons Products falling within CN code 2901 10",
+    "properties": {
+      "unitOfMeasureCode": "1",
+      "degreePlatoApplicabilityFlag": false,
+      "actionIdentification": "1103",
+      "exciseProductsCategoryCode": "E",
+      "alcoholicStrengthApplicabilityFlag": false,
+      "densityApplicabilityFlag": false
+    }
+  },
+  {
+    "key": "S200",
+    "value": "Spirituous beverages",
+    "properties": {
+      "unitOfMeasureCode": "3",
+      "degreePlatoApplicabilityFlag": false,
+      "actionIdentification": "1110",
+      "exciseProductsCategoryCode": "S",
+      "alcoholicStrengthApplicabilityFlag": true,
+      "densityApplicabilityFlag": false
+    }
+  },
+  {
+    "key": "T300",
+    "value": "Cigars & cigarillos",
+    "properties": {
+      "unitOfMeasureCode": "4",
+      "degreePlatoApplicabilityFlag": false,
+      "actionIdentification": "1116",
+      "exciseProductsCategoryCode": "T",
+      "alcoholicStrengthApplicabilityFlag": false,
+      "densityApplicabilityFlag": false
+    }
+  }
+]

--- a/it/test/uk/gov/hmrc/crdlcacheadminfrontend/HealthEndpointIntegrationSpec.scala
+++ b/it/test/uk/gov/hmrc/crdlcacheadminfrontend/HealthEndpointIntegrationSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.crdlcacheadminfrontend
 
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}

--- a/it/test/uk/gov/hmrc/crdlcacheadminfrontend/connectors/CRDLConnectorSpec.scala
+++ b/it/test/uk/gov/hmrc/crdlcacheadminfrontend/connectors/CRDLConnectorSpec.scala
@@ -1,0 +1,322 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.crdlcacheadminfrontend.connectors
+
+import com.github.tomakehurst.wiremock.client.WireMock.*
+import com.github.tomakehurst.wiremock.stubbing.Scenario
+import org.apache.pekko.actor.ActorSystem
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+import play.api.Configuration
+import play.api.http.{HeaderNames, MimeTypes}
+import play.api.libs.json.Json
+import uk.gov.hmrc.crdlcacheadminfrontend.codeLists.models.CodeListEntry
+import uk.gov.hmrc.crdlcacheadminfrontend.config.AppConfig
+import uk.gov.hmrc.http.test.{HttpClientV2Support, WireMockSupport}
+import uk.gov.hmrc.http.{HeaderCarrier, UpstreamErrorResponse}
+
+import java.util.UUID
+
+class CRDLConnectorSpec
+  extends AsyncFlatSpec
+  with Matchers
+  with WireMockSupport
+  with HttpClientV2Support {
+  given ActorSystem   = ActorSystem("test")
+  given HeaderCarrier = HeaderCarrier()
+
+  private val authToken = UUID.randomUUID().toString
+
+  private val appConfig = new AppConfig(
+    Configuration(
+      "microservice.services.crdl-cache.host" -> "localhost",
+      "microservice.services.crdl-cache.port" -> wireMockPort,
+      "internal-auth.token"                   -> authToken,
+      "http-verbs.retries.intervals"          -> List("1.millis")
+    )
+  )
+
+  override lazy val wireMockRootDirectory = "it/test/resources"
+
+  private val crdlConnector = new CRDLConnector(appConfig, httpClientV2)
+
+  "CRDLConnector.fetchCodeList" should "fetch codelist entries when no filtering parameters are provided" in {
+    stubFor(
+      get(urlPathEqualTo("/crdl-cache/lists/BC36"))
+        .withHeader(HeaderNames.AUTHORIZATION, equalTo(authToken))
+        .willReturn(
+          ok()
+            .withHeader(HeaderNames.CONTENT_TYPE, MimeTypes.JSON)
+            .withBodyFile("codelist/BC36-nofilter.json")
+        )
+    )
+
+    val expected = List(
+      CodeListEntry(
+        "E600",
+        "Saturated acyclic hydrocarbons Products falling within CN code 2901 10",
+        Json.obj(
+          "unitOfMeasureCode"                  -> "1",
+          "degreePlatoApplicabilityFlag"       -> false,
+          "actionIdentification"               -> "1103",
+          "exciseProductsCategoryCode"         -> "E",
+          "alcoholicStrengthApplicabilityFlag" -> false,
+          "densityApplicabilityFlag"           -> false
+        )
+      ),
+      CodeListEntry(
+        "S200",
+        "Spirituous beverages",
+        Json.obj(
+          "unitOfMeasureCode"                  -> "3",
+          "degreePlatoApplicabilityFlag"       -> false,
+          "actionIdentification"               -> "1110",
+          "exciseProductsCategoryCode"         -> "S",
+          "alcoholicStrengthApplicabilityFlag" -> true,
+          "densityApplicabilityFlag"           -> false
+        )
+      ),
+      CodeListEntry(
+        "T300",
+        "Cigars & cigarillos",
+        Json.obj(
+          "unitOfMeasureCode"                  -> "4",
+          "degreePlatoApplicabilityFlag"       -> false,
+          "actionIdentification"               -> "1116",
+          "exciseProductsCategoryCode"         -> "T",
+          "alcoholicStrengthApplicabilityFlag" -> false,
+          "densityApplicabilityFlag"           -> false
+        )
+      )
+    )
+
+    crdlConnector
+      .fetchCodeList("BC36")
+      .map { _ shouldBe expected }
+  }
+
+  it should "fetch codelist entries when filtering by keys" in {
+    stubFor(
+      get(urlPathEqualTo("/crdl-cache/lists/BC36"))
+        .withHeader(HeaderNames.AUTHORIZATION, equalTo(authToken))
+        .withQueryParam("keys", equalTo("E600,T300"))
+        .willReturn(
+          ok()
+            .withHeader(HeaderNames.CONTENT_TYPE, MimeTypes.JSON)
+            .withBodyFile("codelist/BC36-filterkeys.json")
+        )
+    )
+
+    val expected = List(
+      CodeListEntry(
+        "E600",
+        "Saturated acyclic hydrocarbons Products falling within CN code 2901 10",
+        Json.obj(
+          "unitOfMeasureCode"                  -> "1",
+          "degreePlatoApplicabilityFlag"       -> false,
+          "actionIdentification"               -> "1103",
+          "exciseProductsCategoryCode"         -> "E",
+          "alcoholicStrengthApplicabilityFlag" -> false,
+          "densityApplicabilityFlag"           -> false
+        )
+      ),
+      CodeListEntry(
+        "T300",
+        "Cigars & cigarillos",
+        Json.obj(
+          "unitOfMeasureCode"                  -> "4",
+          "degreePlatoApplicabilityFlag"       -> false,
+          "actionIdentification"               -> "1116",
+          "exciseProductsCategoryCode"         -> "T",
+          "alcoholicStrengthApplicabilityFlag" -> false,
+          "densityApplicabilityFlag"           -> false
+        )
+      )
+    )
+
+    crdlConnector
+      .fetchCodeList(
+        "BC36",
+        filterKeys = Some(Set("E600", "T300"))
+      )
+      .map {
+        _ shouldBe expected
+      }
+  }
+
+  it should "fetch codelist entries when filtering by properties" in {
+    stubFor(
+      get(urlPathEqualTo("/crdl-cache/lists/BC36"))
+        .withHeader(HeaderNames.AUTHORIZATION, equalTo(authToken))
+        .withQueryParam("alcoholicStrengthApplicabilityFlag", equalTo("true"))
+        .willReturn(
+          ok()
+            .withHeader(HeaderNames.CONTENT_TYPE, MimeTypes.JSON)
+            .withBodyFile("codelist/BC36-filterproperties.json")
+        )
+    )
+
+    val expected = List(
+      CodeListEntry(
+        "S200",
+        "Spirituous beverages",
+        Json.obj(
+          "unitOfMeasureCode"                  -> "3",
+          "degreePlatoApplicabilityFlag"       -> false,
+          "actionIdentification"               -> "1110",
+          "exciseProductsCategoryCode"         -> "S",
+          "alcoholicStrengthApplicabilityFlag" -> true,
+          "densityApplicabilityFlag"           -> false
+        )
+      )
+    )
+
+    crdlConnector
+      .fetchCodeList(
+        "BC36",
+        filterProperties = Some(Map("alcoholicStrengthApplicabilityFlag" -> true))
+      )
+      .map {
+        _ shouldBe expected
+      }
+  }
+
+  it should "throw UpstreamErrorResponse when crdl-cache returns a client error" in {
+    stubFor(
+      get(urlPathEqualTo("/crdl-cache/lists/BC999"))
+        .withHeader(HeaderNames.AUTHORIZATION, equalTo(authToken))
+        .willReturn(badRequest())
+    )
+
+    recoverToSucceededIf[UpstreamErrorResponse] {
+      crdlConnector.fetchCodeList("BC999")
+    }
+  }
+
+  it should "throw UpstreamErrorResponse when crdl-cache returns a server error consistently" in {
+    stubFor(
+      get(urlPathEqualTo("/crdl-cache/lists/BC36"))
+        .withHeader(HeaderNames.AUTHORIZATION, equalTo(authToken))
+        .willReturn(serverError())
+    )
+
+    recoverToSucceededIf[UpstreamErrorResponse] {
+      crdlConnector.fetchCodeList("BC36")
+    }
+  }
+
+  it should "not retry when crdl-cache returns a client error" in {
+    val retryScenario = "Retry"
+    val failedState   = "Failed"
+
+    stubFor(
+      get(urlPathEqualTo("/crdl-cache/lists/BC999"))
+        .inScenario(retryScenario)
+        .whenScenarioStateIs(Scenario.STARTED)
+        .withHeader(HeaderNames.AUTHORIZATION, equalTo(authToken))
+        .willReturn(badRequest())
+        .willSetStateTo(failedState)
+    )
+
+    // Queue up a success response for the second call, which should never happen
+    stubFor(
+      get(urlPathEqualTo("/crdl-cache/lists/BC999"))
+        .inScenario(retryScenario)
+        .whenScenarioStateIs(failedState)
+        .withHeader(HeaderNames.AUTHORIZATION, equalTo(authToken))
+        .willReturn(
+          ok()
+            .withHeader(HeaderNames.CONTENT_TYPE, MimeTypes.JSON)
+            .withBodyFile("codelist/BC36-nofilter.json")
+        )
+    )
+
+    recoverToSucceededIf[UpstreamErrorResponse] {
+      crdlConnector.fetchCodeList("BC999")
+    }
+  }
+
+  it should "retry when crdl-cache returns a server error" in {
+    val retryScenario = "Retry"
+    val failedState   = "Failed"
+
+    stubFor(
+      get(urlPathEqualTo("/crdl-cache/lists/BC36"))
+        .inScenario(retryScenario)
+        .whenScenarioStateIs(Scenario.STARTED)
+        .withHeader(HeaderNames.AUTHORIZATION, equalTo(authToken))
+        .willReturn(serverError())
+        .willSetStateTo(failedState)
+    )
+
+    // Queue up a success response for the retry
+    stubFor(
+      get(urlPathEqualTo("/crdl-cache/lists/BC36"))
+        .inScenario(retryScenario)
+        .whenScenarioStateIs(failedState)
+        .withHeader(HeaderNames.AUTHORIZATION, equalTo(authToken))
+        .willReturn(
+          ok()
+            .withHeader(HeaderNames.CONTENT_TYPE, MimeTypes.JSON)
+            .withBodyFile("codelist/BC36-nofilter.json")
+        )
+    )
+
+    val expected = List(
+      CodeListEntry(
+        "E600",
+        "Saturated acyclic hydrocarbons Products falling within CN code 2901 10",
+        Json.obj(
+          "unitOfMeasureCode"                  -> "1",
+          "degreePlatoApplicabilityFlag"       -> false,
+          "actionIdentification"               -> "1103",
+          "exciseProductsCategoryCode"         -> "E",
+          "alcoholicStrengthApplicabilityFlag" -> false,
+          "densityApplicabilityFlag"           -> false
+        )
+      ),
+      CodeListEntry(
+        "S200",
+        "Spirituous beverages",
+        Json.obj(
+          "unitOfMeasureCode"                  -> "3",
+          "degreePlatoApplicabilityFlag"       -> false,
+          "actionIdentification"               -> "1110",
+          "exciseProductsCategoryCode"         -> "S",
+          "alcoholicStrengthApplicabilityFlag" -> true,
+          "densityApplicabilityFlag"           -> false
+        )
+      ),
+      CodeListEntry(
+        "T300",
+        "Cigars & cigarillos",
+        Json.obj(
+          "unitOfMeasureCode"                  -> "4",
+          "degreePlatoApplicabilityFlag"       -> false,
+          "actionIdentification"               -> "1116",
+          "exciseProductsCategoryCode"         -> "T",
+          "alcoholicStrengthApplicabilityFlag" -> false,
+          "densityApplicabilityFlag"           -> false
+        )
+      )
+    )
+
+    crdlConnector
+      .fetchCodeList("BC36")
+      .map { _ shouldBe expected }
+  }
+}

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,6 +4,7 @@ import sbt._
 object AppDependencies {
 
   private val bootstrapVersion = "10.1.0"
+  private val httpVerbsVersion = "15.6.0"
   private val playVersion = "play-30"
   
 
@@ -16,6 +17,7 @@ object AppDependencies {
 
   val test = Seq(
     "uk.gov.hmrc"             %% "bootstrap-test-play-30"     % bootstrapVersion    % Test,
+    "uk.gov.hmrc"             %% "http-verbs-test-play-30"     % httpVerbsVersion % Test,
     "org.jsoup"               %  "jsoup"                      % "1.13.1"            % Test,
   )
 

--- a/test/uk/gov/hmrc/crdlcacheadminfrontend/config/ErrorHandlerSpec.scala
+++ b/test/uk/gov/hmrc/crdlcacheadminfrontend/config/ErrorHandlerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.crdlcacheadminfrontend.config
 
 import org.scalatest.concurrent.ScalaFutures


### PR DESCRIPTION
This illustrates the pattern we use for connector tests:

* Set up stubs with Wiremock
* Test all relevant headers and query params
* Test client and server error behaviour
* Exercise retry behaviour

This makes sure that we are passing along any necessary authentication headers and that our deserialization code is working.